### PR TITLE
Fix spelling of Software

### DIFF
--- a/pmaweb/templates/index.html
+++ b/pmaweb/templates/index.html
@@ -55,7 +55,7 @@ base; you can find out more about the <a href="{% url 'about' %}">project and it
 </p>
 
 <p>
-The phpMyAdmin project is a member of <a href="https://sfconservancy.org">Sofware Freedom Conservancy</a>. SFC is a not-for-profit organization that helps promote, improve, develop, and defend Free, Libre, and Open Source Software (FLOSS) projects.
+The phpMyAdmin project is a member of <a href="https://sfconservancy.org">Software Freedom Conservancy</a>. SFC is a not-for-profit organization that helps promote, improve, develop, and defend Free, Libre, and Open Source Software (FLOSS) projects.
 </p>
 
 <div class="sfc-logo">


### PR DESCRIPTION
Software is misspelled as 'Sofware' in link to SFC.