### PR TITLE
Feature the most usual download option

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -228,6 +228,14 @@ class Release(models.Model):
 
         return text
 
+    def get_downloads(self):
+        """Lists downloads, making all-languages.zip first"""
+        dlset = self.download_set
+        return (
+            list(dlset.filter(filename__endswith='all-languages.zip')) +
+            list(dlset.exclude(filename__endswith='all-languages.zip'))
+        )
+
 
 class Download(models.Model):
     release = models.ForeignKey(Release)
@@ -291,6 +299,10 @@ class Download(models.Model):
             return 'zip'
         else:
             return 'tar'
+
+    @property
+    def is_featured(self):
+        return self.filename.endswith('all-languages.zip')
 
 
 class Theme(models.Model):

--- a/pmaweb/static/css/style.css
+++ b/pmaweb/static/css/style.css
@@ -177,3 +177,7 @@ footer li{
     display: block;
     margin: 5px;
 }
+
+.featured-dl {
+    font-weight: bold;
+}

--- a/pmaweb/templates/_dllist.html
+++ b/pmaweb/templates/_dllist.html
@@ -1,6 +1,6 @@
 <p>{{ release.get_version_info }}</p>
 
-{% with release.download_set.all as download_list %}
+{% with release.get_downloads as download_list %}
 
 {% if download_list %}
 {% include '_dltable.html' %}

--- a/pmaweb/templates/_dlrow.html
+++ b/pmaweb/templates/_dlrow.html
@@ -1,4 +1,4 @@
-    <tr>
+    <tr {% if file.is_featured %}class="featured-dl"{% endif %}>
         <td><a href="{{ file.get_absolute_url }}" class="download_popup" data-sha1="{{ file.sha1 }}" data-sha256="{{ file.sha256 }}" data-pgp="{{ file.get_signed_url }}">{{ file.filename }}</a></td>
         <td class="td-size">{{ file.size | filesizeformat }}</td>
         <td>


### PR DESCRIPTION
Most people want all-languages.zip, so let's make it clear:

* show it first in the listings
* show it bold

Signed-off-by: Michal Čihař <michal@cihar.com>

The release lists now render as:

![phpmyadmin_-_downloads_-_2016-12-19_13 44 12](https://cloud.githubusercontent.com/assets/212189/21313323/723467ac-c5f1-11e6-87c3-37b737f01ad3.png)
