### PR TITLE
Fix latest checksum urls

### DIFF
--- a/files/models.py
+++ b/files/models.py
@@ -325,6 +325,11 @@ class Download(models.Model):
             self.__unicode__()
         )
 
+    def get_checksum_url(self):
+        return 'https://files.phpmyadmin.net{0}.sha256'.format(
+            self.__unicode__()
+        )
+
     def get_alternate_url(self):
         return 'https://1126968067.rsc.cdn77.org{0}'.format(
             self.__unicode__()
@@ -460,6 +465,7 @@ def purge_release(sender, instance, **kwargs):
         '/downloads/phpMyAdmin-latest-english.tar.gz',
         '/downloads/phpMyAdmin-latest-english.tar.xz',
         '/downloads/phpMyAdmin-latest-english.zip',
+        '/downloads/phpMyAdmin-latest-source.tar.xz',
         reverse('doap'),
         reverse('pad'),
         # This release

--- a/files/tests.py
+++ b/files/tests.py
@@ -22,6 +22,7 @@
 
 from django.test import TestCase
 from files.models import Release
+from files.models import Download
 
 
 class ReleaseTest(TestCase):
@@ -50,3 +51,74 @@ class ReleaseTest(TestCase):
             Release.parse_version('1.2.3-alpha2'),
             102030002
         )
+
+    def test_urls(self):
+        r = Release()
+        r.version = "1.2.3"
+        d = Download()
+        d.release = r
+        d.filename = "english.zip"
+        self.assertEquals(
+            d.get_checksum_url(),
+            'https://files.phpmyadmin.net/phpMyAdmin/1.2.3/english.zip.sha256'
+        )
+        self.assertEquals(
+            d.get_signed_url(),
+            ''
+        )
+        d.signed = True
+        self.assertEquals(
+            d.get_signed_url(),
+            'https://files.phpmyadmin.net/phpMyAdmin/1.2.3/english.zip.asc'
+        )
+        self.assertEquals(
+            d.get_absolute_url(),
+            'https://files.phpmyadmin.net/phpMyAdmin/1.2.3/english.zip'
+        )
+        self.assertEquals(
+            d.archive,
+            'zip'
+        )
+        self.assertEquals(
+            d.composer_type,
+            'zip'
+        )
+        d.filename = 'english.xz'
+        self.assertEquals(
+            d.composer_type,
+            'tar'
+        )
+        d.filename = 'english.zip'
+        self.assertEquals(
+            d.composer_type,
+            'zip'
+        )
+        self.assertEquals(
+            d.is_featured,
+            False
+        )
+        d.filename = 'all-languages.zip'
+        self.assertEquals(
+            d.is_featured,
+            True
+        )
+        d.filename = 'english.zip'
+        self.assertEquals(
+            d.is_featured,
+            False
+        )
+        d.filename = 'phpMyAdmin-latest-all-languages.zip'
+        self.assertEquals(
+            d.get_stable_url,
+            '/downloads/phpMyAdmin-latest-all-languages.zip'
+        )
+        self.assertEquals(
+            d.get_stable_filename,
+            'phpMyAdmin-latest-all-languages.zip'
+        )
+        d.filename = 'phpMyAdmin-latest-all-languages.tar.xz'
+        self.assertEquals(
+            d.get_stable_filename,
+            'phpMyAdmin-latest-all-languages.tar.xz'
+        )
+

--- a/files/views.py
+++ b/files/views.py
@@ -95,6 +95,8 @@ def latest_download(request, flavor, extension, checksum=None):
         )
         if checksum == '.asc':
             return redirect(result.get_signed_url(), permanent=False)
+        if checksum == '.sha256':
+            return redirect(result.get_checksum_url('sha256'), permanent=False)
         return redirect(result, permanent=False)
     except Download.DoesNotExist:
         raise Http404("No release found matching the query")


### PR DESCRIPTION
- Fix `/downloads/phpMyAdmin-latest-all-languages.{zip,.tar.gz,.tar.xz,.7z,.tar.bz2}.sha256`
- Fix `/downloads/phpMyAdmin-latest-all-languages.{zip,.tar.gz,.tar.xz,.7z,.tar.bz2}.sha1`
- Fix `/downloads/phpMyAdmin-latest-source.tar.xz.sha256`
- Fix `/downloads/phpMyAdmin-latest-source.tar.xz.sha1`

Fixes: https://github.com/phpmyadmin/phpmyadmin/issues/14616