### PR TITLE
Add workflow to check daily snapshots

### DIFF
--- a/.github/workflows/monitoring.yml
+++ b/.github/workflows/monitoring.yml
@@ -1,0 +1,28 @@
+name: "Monitoring"
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 18 * * *"
+
+jobs:
+  daily_snapshots:
+    name: "Daily snapshots"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v2"
+
+      - name: "Set up Python"
+        uses: "actions/setup-python@v2"
+        with:
+          python-version: "3.x"
+
+      - name: "Install requirements"
+        run: |
+          pip install beautifulsoup4
+
+      - name: "Check daily snapshots"
+        run: |
+          ./monitoring/check_phpmyadmin_daily_snapshots.py

--- a/monitoring/check_phpmyadmin_daily_snapshots.py
+++ b/monitoring/check_phpmyadmin_daily_snapshots.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+# I suggest creating a venv for this. I did it with `python3 -m venv daily_snapshot_venv` then source that with `source daily_snapshot_venv/bin/activate`.
+# Install 'beautifulsoup4' to the venv
+
+# This program checks that the phpMyAdmin daily downloads are within a day or two of the current time.
+# We allow an extra day of wiggle room because of the possibility of working in different time zones.
+#
+# Written by Isaac Bennetch <bennetch@gmail.com>
+
+import sys
+import urllib.request
+try:
+    from bs4 import BeautifulSoup
+except ModuleNotFoundError:
+    print("The BeautifulSoup module is not available. Please make sure you have the proper module or are running the correct venv.")
+    sys.exit(1)
+import datetime
+
+#############
+# Main code #
+#############
+
+
+download_url = 'https://www.phpmyadmin.net/downloads/'
+
+page = urllib.request.urlopen(download_url)
+soup = BeautifulSoup(page, 'html.parser')
+full_text = soup.get_text()
+split = full_text.split("generated")
+
+today_date = datetime.date.today()
+
+exit_code = 0
+
+# Process each instance of the keyword on the page, because we can have multiple QA and master versions
+for substring in split:
+  # Take only the date, not the entire page following it
+  generated_date = substring.split()[0]
+  # Strip off the trailing comma
+  if generated_date.endswith(','):
+    generated_date = generated_date[:-1]
+  if generated_date != 'phpMyAdmin':
+    converted_date = datetime.datetime.strptime(generated_date, '%Y-%m-%d').date()
+    difference = today_date - converted_date
+    # We give an extra day as a buffer to account for time zones
+    if difference > datetime.timedelta(days=1):
+      print("Problem found")
+      print("Current date: " + today_date.strftime('%Y-%m-%d'))
+      print("Snapshot date: " + generated_date)
+      exit_code = 1
+    else:
+      print("Everything is groovy")
+
+sys.exit(exit_code)


### PR DESCRIPTION
Runs a daily check of the phpMyAdmin daily snapshots.

The python script was copied from the [phpmyadmin/scripts](https://github.com/phpmyadmin/scripts) repository. But exit codes were added to be able to mark the job as failed.

I think the `website` repository is more suitable for this workflow, but it can be moved back to the `scripts` repository if necessary.

![Screenshot of the GitHub Actions log showing a failed check](https://user-images.githubusercontent.com/120970/154717545-d60aeb14-ea06-44df-968b-6e6a8bf9d2a9.png)

- https://github.com/phpmyadmin/website/runs/5250113524
