### PR TITLE
Gracefully handling missing screenshot in the theme page. No error

### DIFF
--- a/files/templatetags/file_check.py
+++ b/files/templatetags/file_check.py
@@ -1,0 +1,17 @@
+import os.path
+
+from django import template
+from django.templatetags.static import static
+from django.conf import settings
+from os import path
+
+register = template.Library()
+
+@register.filter(name='image_exists')
+
+def image_exists(filepath):
+    imagePath = settings.BASE_DIR+'/pmaweb/'+static(filepath);
+    if path.exists(imagePath):
+        return True
+    else:
+        return False

--- a/pmaweb/templates/themes.html
+++ b/pmaweb/templates/themes.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% load staticfiles %}
+{% load file_check %}
 
 {% block content %}
 <h2>Themes</h2>
@@ -49,9 +50,11 @@ request to <a href="https://github.com/phpmyadmin/themes/pulls">https://github.c
   </div>
   <div class="card-body">
             <div class="pull-right thumbnail">
-                <a href="{% static theme.imgname %}" class="colorbox" title="{{theme.name}} theme">
-                    <img src="{% static theme.imgname %}" alt="{{theme.display_name}} thumbnail" class="themeimg" />
-                </a>
+              {% if theme.imgname|image_exists %}
+              <a href="{% static theme.imgname %}" class="colorbox" title="{{theme.name}} theme">
+                <img src="{% static theme.imgname %}" alt="{{theme.display_name}} thumbnail" class="themeimg" />
+              </a>
+              {% endif %}
             </div>
             <p>Released on {{theme.date|date:"Y-m-d"}}</p>
             <p>Compatible with phpMyAdmin <strong>{{theme.supported_versions}}</strong>.</p>


### PR DESCRIPTION
Signed-off-by: Vimal K <vimalinfo10@gmail.com>

### Description
Gracefully handling missing screenshot in the theme page. In case of no screenshots available, the image div will be empty showing nothing.

Please find below images showing use case with and without .

### with available screenshot
![image](https://user-images.githubusercontent.com/35750792/198165332-3946525f-7536-479e-a0df-5dc5073ce249.png)

### without available screenshot
![image](https://user-images.githubusercontent.com/35750792/198165390-787fbed2-42ee-4dfa-b00d-46ad3c7ec4c7.png)

### Issues Resolved
Closes #139 

### Testing Browser
 - [x] Chrome
 - [x] Microsoft Edge
 - [x] Mozilla Firefox

### Check List
Commits are signed per the DCO using --signoff