### PR TITLE
Fix #30: Implement Custom Error Pages

### DIFF
--- a/pmaweb/settings.py
+++ b/pmaweb/settings.py
@@ -44,7 +44,7 @@ ADMINS = (
 SECRET_KEY = 'n$6di6axa*m5)$%yzhl6xhe%^b4t^)6#sbz_b5_7&ga@12(+_h'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = (
     '127.0.0.1',
@@ -172,3 +172,5 @@ DOCKERHUB_TOKEN = None
 
 GITHUB_USER = 'phpmyadmin-bot'
 GITHUB_TOKEN = None
+
+COMPRESS_ENABLED = os.environ.get('COMPRESS_ENABLED', False)

--- a/pmaweb/static/css/style.css
+++ b/pmaweb/static/css/style.css
@@ -138,6 +138,14 @@ div.subscribe {
 .sfc-logo {
     text-align: center;
 }
+
+footer {
+    display: table;
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+    padding-right:50px;
+}
 footer ul {
     padding:0;
     margin:1em;

--- a/pmaweb/templates/404.html
+++ b/pmaweb/templates/404.html
@@ -3,15 +3,17 @@
 
 {% block content %}
 
-<h2>Page Not Found</h2>
+
+<h3>
+  <svg xmlns="http://www.w3.org/2000/svg" width="35" height="35" viewBox="0 0 24 24" fill="none" stroke="#000000" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"></circle><line x1="12" y1="8" x2="12" y2="12"></line><line x1="12" y1="16" x2="12.01" y2="16"></line></svg>
+   Page Not Found
+</h3>
 
 <p>
-The requested URL was not found on this server. This might have several
-causes, but if you found this link on some page, you should notify its author
-that it no longer works. Please follow to our <a href="{% url 'home' %}">main
+The requested URL was not found on this server. Please visit our <a href="{% url 'home' %}">main
 page</a> to find information you were looking for or use the navigation bar above.
 </p>
-
+<p>If you want to report the missing page. Please visit  <a href="{% url 'support' %}">Support</a> </p>
 <script type="text/javascript">
 var GOOG_FIXURL_LANG = 'en';
 var GOOG_FIXURL_SITE = 'https://www.phpmyadmin.net/';


### PR DESCRIPTION
Signed-off-by: Vimal K <vimalinfo10@gmail.com>

### Description
- Implement Custom Error Pages
- Collaterally fixed footer alignment to center of page.

### Screenshots
Error Page looks like:
![image](https://user-images.githubusercontent.com/35750792/199661069-e32c5714-bc50-4edd-8cb7-bca10a6101f3.png)


IMPORTANT NOTE:

 settings.py should be having these changes for the custom error pages to work. If DEBUG = TRUE ,it means DEV ENV and custom pages will not work.


DEBUG = FALSE
COMPRESS_ENABLED = os.environ.get('COMPRESS_ENABLED', False)'



### Issues Resolved
Closes #30 

### Testing Browser
- [x] Chrome
- [x] Microsoft Edge
- [x] Mozilla Firefox
 

### Check List
Commits are signed per the DCO using --signoff