### PR TITLE
Fix Django 1.11 deprecations

### DIFF
--- a/demo/management/commands/fetch_versions.py
+++ b/demo/management/commands/fetch_versions.py
@@ -24,7 +24,7 @@ from ConfigParser import RawConfigParser
 import urllib
 
 from django.core.management.base import BaseCommand
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from demo.models import Demo
 

--- a/files/migrations/0001_initial.py
+++ b/files/migrations/0001_initial.py
@@ -66,7 +66,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='download',
             name='release',
-            field=models.ForeignKey(to='files.Release'),
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='files.Release'),
         ),
         migrations.AlterUniqueTogether(
             name='download',

--- a/files/models.py
+++ b/files/models.py
@@ -319,7 +319,7 @@ class Release(models.Model):
 
 
 class Download(models.Model):
-    release = models.ForeignKey(Release)
+    release = models.ForeignKey(Release, on_delete=models.CASCADE)
     filename = models.CharField(max_length=50)
     size = models.IntegerField(default=0)
     sha1 = models.CharField(max_length=40)

--- a/files/models.py
+++ b/files/models.py
@@ -23,7 +23,7 @@ import json
 import urllib2
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.conf import settings
 from django.utils import timezone

--- a/files/views.py
+++ b/files/views.py
@@ -22,7 +22,7 @@
 
 from django.views.generic.list import ListView
 from django.views.generic.detail import DetailView
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, Http404
 from django.shortcuts import redirect
 from files.models import Release, get_current_releases, Download

--- a/news/migrations/0001_initial.py
+++ b/news/migrations/0001_initial.py
@@ -36,7 +36,7 @@ class Migration(migrations.Migration):
                 ('body', markupfield.fields.MarkupField(rendered_field=True)),
                 ('body_markup_type', models.CharField(default=b'markdown', max_length=30, choices=[(b'', b'--'), (b'html', 'HTML'), (b'plain', 'Plain'), (b'markdown', 'Markdown'), (b'restructuredtext', 'Restructured Text')])),
                 ('_body_rendered', models.TextField(editable=False)),
-                ('author', models.ForeignKey(editable=False, to=settings.AUTH_USER_MODEL)),
+                ('author', models.ForeignKey(editable=False, on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
             ],
             options={
                 'ordering': ['-date'],

--- a/news/models.py
+++ b/news/models.py
@@ -45,12 +45,10 @@ class Post(models.Model):
     def __unicode__(self):
         return self.title
 
-    @models.permalink
     def get_absolute_url(self):
-        return (
+        return reverse(
             'news-item',
-            (),
-            {
+            kwargs={
                 'day': self.date.day,
                 'month': self.date.month,
                 'year': self.date.year,

--- a/news/models.py
+++ b/news/models.py
@@ -21,7 +21,7 @@
 #
 
 from django.dispatch import receiver
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models.signals import post_save
 from django.db import models
 from django.utils import timezone

--- a/news/models.py
+++ b/news/models.py
@@ -37,7 +37,7 @@ class Post(models.Model):
     )
     date = models.DateTimeField(db_index=True, default=timezone.now)
     body = MarkupField(default_markup_type='markdown')
-    author = models.ForeignKey(User, editable=False)
+    author = models.ForeignKey(User, on_delete=models.CASCADE, editable=False)
 
     class Meta(object):
         ordering = ['-date']

--- a/pmaweb/context_processors.py
+++ b/pmaweb/context_processors.py
@@ -24,7 +24,7 @@ from news.models import Post, Planet
 from translations.models import Translation
 from security.models import PMASA
 from demo.models import Demo
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 import datetime
 

--- a/pmaweb/sitemaps.py
+++ b/pmaweb/sitemaps.py
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from django.contrib.sitemaps import GenericSitemap, Sitemap
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils import timezone
 from news.models import Post
 from security.models import PMASA

--- a/pmaweb/tests.py
+++ b/pmaweb/tests.py
@@ -22,7 +22,7 @@
 
 from xml.etree import cElementTree as ElementTree
 from django.test import TestCase, override_settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.timezone import utc, make_aware
 import httpretty
 import datetime

--- a/pmaweb/urls.py
+++ b/pmaweb/urls.py
@@ -19,7 +19,7 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
-from django.conf.urls import include, url
+from django.conf.urls import url
 from django.contrib import admin
 from django.views.generic import RedirectView
 from django.views.generic import TemplateView
@@ -560,5 +560,5 @@ urlpatterns = [
     ),
 
     # Admin interface
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/pmaweb/views.py
+++ b/pmaweb/views.py
@@ -26,7 +26,7 @@ import base64
 
 from django.conf import settings
 from django.shortcuts import redirect
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse, Http404, HttpResponseServerError
 from django.views.decorators.cache import cache_control
 from django.views.generic import TemplateView

--- a/security/models.py
+++ b/security/models.py
@@ -89,16 +89,14 @@ class PMASA(models.Model):
     def __unicode__(self):
         return 'PMASA-{0}-{1}'.format(self.year, self.sequence)
 
-    @models.permalink
     def get_absolute_url(self):
         if self.draft:
             page = 'security-issue-draft'
         else:
             page = 'security-issue'
-        return (
+        return reverse(
             page,
-            (),
-            {'year': self.year, 'sequence': self.sequence}
+            kwargs={'year': self.year, 'sequence': self.sequence}
         )
 
     def get_cves(self):

--- a/security/models.py
+++ b/security/models.py
@@ -21,7 +21,7 @@
 #
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.utils import timezone
 from markupfield.fields import MarkupField

--- a/security/views.py
+++ b/security/views.py
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 #
 from django.views.generic.detail import DetailView
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404
 from django.shortcuts import redirect
 from security.models import PMASA


### PR DESCRIPTION
Those are the deprecations reported by the tests:

- Old-style middleware using settings.MIDDLEWARE_CLASSES is deprecated. Update your middleware and use settings.MIDDLEWARE instead. (Fixed by bfef7889bcc8b0a961db0a46a4b1a2c2b4591665)
- Importing from django.core.urlresolvers is deprecated in favor of django.urls.
- on_delete will be a required arg for ForeignKey in Django 2.0. Set it to models.CASCADE on models and in existing migrations if you want to maintain the current default behavior.
- permalink() is deprecated in favor of calling django.urls.reverse() in the decorated method.
- Passing a 3-tuple to django.conf.urls.include() is deprecated. Pass a 2-tuple containing the list of patterns and app_name, and provide the namespace argument to include() instead.