### PR TITLE
Change PHP Version in Supported Version to match other info

### DIFF
--- a/pmaweb/templates/downloads.html
+++ b/pmaweb/templates/downloads.html
@@ -154,7 +154,7 @@
                 <td>4.9</td>
                 <td>December 31, 2019</td>
                 <td>TBD</td>
-                <td>LTS to support PHP 5.5-7.0</td>
+                <td>LTS to support PHP 5.5-7.4</td>
             </tr>
             <tr>
                 <td>4.8</td>


### PR DESCRIPTION
Under headline "phpMyAdmin 4.9.11" you write: `Older version compatible with PHP 5.5 to 7.4`. in table "Supported versions" you write `LTS to support PHP 5.5-7.0`. that PR unifies that info