### PR TITLE
Fix empty entry in demo list

### DIFF
--- a/demo/management/commands/fetch_versions.py
+++ b/demo/management/commands/fetch_versions.py
@@ -20,7 +20,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 from collections import OrderedDict
-from configparser import RawConfigParser
+from configparser import ConfigParser
 import urllib.request, urllib.parse, urllib.error
 
 from django.core.management.base import BaseCommand
@@ -47,7 +47,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         handle = urllib.request.urlopen(URL)
-        config = RawConfigParser(dict_type=MultiOrderedDict, strict=False)
+        config = ConfigParser(dict_type=MultiOrderedDict, strict=False, empty_lines_in_values=False, interpolation=None)
         try:
             config.read_string(handle.read().decode('utf-8'))
         except Exception as e:
@@ -60,13 +60,13 @@ class Command(BaseCommand):
             import sys
             sys.exit(1)
 
-        master = config.get('demo', 'master-release')[0]
+        master = config['demo']['master-release'][0]
 
         modified = False
 
         processed = set()
 
-        for version in config.get('demo', 'branches[]'):
+        for version in config['demo']['branches[]']:
             demo, created = Demo.objects.get_or_create(
                 name=version,
                 defaults={'master_version': master}

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: UTF-8 -*-
 # vim: set expandtab sw=4 ts=4 sts=4:
 #


### PR DESCRIPTION
The `fetch_versions.py` was including an empty entry in the demo server list.

Replaces the legacy `RawConfigParser` object with `ConfigParser(interpolation=None)`.

```diff
- ['master', 'master-config', 'master-http', 'master-config-nopmadb', 'STABLE', 'QA_4_9', 'QA_5_2', '']
+ ['master', 'master-config', 'master-http', 'master-config-nopmadb', 'STABLE', 'QA_4_9', 'QA_5_2']
```

Before:
![Screenshot from 2023-10-04 17-46-35](https://github.com/phpmyadmin/website/assets/120970/86295467-580c-4760-a737-e3936be1d85a)

After:
![Screenshot from 2023-10-04 17-46-28](https://github.com/phpmyadmin/website/assets/120970/bfbb493d-41d4-4a52-821e-5c0b983e0328)
