### PR TITLE
Update Composer notice saying PMA is not on Packagist

### DIFF
--- a/pmaweb/templates/downloads.html
+++ b/pmaweb/templates/downloads.html
@@ -90,9 +90,8 @@
     <h2><a id="composer"></a>Installing using Composer</h2>
 
     <p>
-        Due to technical limitations, we're currently unable to publish
-        phpMyAdmin directly in Packagist repository, but it is possible to
-        install phpMyAdmin from our own Composer repository. Please check
+        It is possible to install phpMyAdmin from Packagist or our own
+        Composer repository. Please check
         <a href="https://docs.phpmyadmin.net/en/latest/setup.html#composer">our manual</a>
         for more information.
     </p>


### PR DESCRIPTION
This seems to be outdated, as the documentation at https://docs.phpmyadmin.net/en/latest/setup.html#installing-using-composer says:

> You can install phpMyAdmin using the Composer tool, since 4.7.0 the releases are automatically mirrored to the default Packagist repository.