### PR TITLE
Fix active state for nested URLs in navigation

### DIFF
--- a/pmaweb/context_processors.py
+++ b/pmaweb/context_processors.py
@@ -60,10 +60,13 @@ def menu(request):
         else:
             urlname = 'home'
 
-        active = (
-            request.resolver_match and
-            urlname == request.resolver_match.url_name
-        )
+        if urlname == 'home':
+            active = request.path == reverse(urlname)
+        else:
+            active = (
+                request.resolver_match and
+                request.path.startswith(reverse(urlname))
+            )
 
         result.append({
             'title': title,


### PR DESCRIPTION
This fixes an issue where menu items are not shown as active when you are on a nested URL.

Example:

![image](https://github.com/user-attachments/assets/45491dac-2975-4bc4-b496-39c0770c378c)

![image](https://github.com/user-attachments/assets/bd956f89-9217-457a-9fec-d497471c0d63)
